### PR TITLE
Update public profile with license text and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # .github
 
-This repo contains org-wide default [community-health check files](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file#supported-file-types).
+This repository hosts [our public profile](profile/README.md) and our org-wide default [community-health check files](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file#supported-file-types).

--- a/profile/README.md
+++ b/profile/README.md
@@ -19,10 +19,23 @@ AH Technology fulfills several important roles: making (online) shopping easier,
 
 ## License
 
-All our projects have the following lincense:
-Copyright 2020-2022 © The Backstage Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage
+All our projects have the [Apache License, Version 2.0](../LICENSE):
 
-Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+```text
+Copyright 2020-2022 Albert Heijn Technology
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
 
 ## Security
 


### PR DESCRIPTION
Correct a typo in the license introduction, fix the license snippet
and update the project README with a link to the public profile.